### PR TITLE
Added engine version to cluster bus

### DIFF
--- a/src/cluster.h
+++ b/src/cluster.h
@@ -148,6 +148,7 @@ typedef struct clusterNode {
     clusterLink *link;          /* TCP/IP link established toward this node */
     clusterLink *inbound_link;  /* TCP/IP link accepted from this node */
     list *fail_reports;         /* List of nodes signaling this as failing */
+    sds engine_version;         /* The node's engine version */
 } clusterNode;
 
 /* Slot to keys for a single slot. The keys in the same slot are linked together
@@ -262,6 +263,7 @@ typedef enum {
     CLUSTERMSG_EXT_TYPE_HOSTNAME,
     CLUSTERMSG_EXT_TYPE_FORGOTTEN_NODE,
     CLUSTERMSG_EXT_TYPE_SHARDID,
+    CLUSTERMSG_EXT_TYPE_ENGINE_VERSION,
 } clusterMsgPingtypes; 
 
 /* Helper function for making sure extensions are eight byte aligned. */
@@ -270,6 +272,10 @@ typedef enum {
 typedef struct {
     char hostname[1]; /* The announced hostname, ends with \0. */
 } clusterMsgPingExtHostname;
+
+typedef struct {
+    char engine_version[1]; /* The node's engine_version, ends with \0. */
+} clusterMsgPingExtEngineVersion;
 
 typedef struct {
     char name[CLUSTER_NAMELEN]; /* Node name. */
@@ -290,6 +296,7 @@ typedef struct {
         clusterMsgPingExtHostname hostname;
         clusterMsgPingExtForgottenNode forgotten_node;
         clusterMsgPingExtShardId shard_id;
+        clusterMsgPingExtEngineVersion engine_version;
     } ext[]; /* Actual extension information, formatted so that the data is 8 
               * byte aligned, regardless of its content. */
 } clusterMsgPingExt;

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -100,6 +100,7 @@ set ::all_tests {
     unit/cluster/hostnames
     unit/cluster/multi-slot-operations
     unit/cluster/slot-ownership
+    unit/cluster/engine-versions
 }
 # Index to the next test to run in the ::all_tests list.
 set ::next_test 0

--- a/tests/unit/cluster/engine-versions.tcl
+++ b/tests/unit/cluster/engine-versions.tcl
@@ -1,0 +1,43 @@
+# Check if cluster's view of engine versions is consistent
+proc are_engine_version_propagated {match_string} {
+    for {set j 0} {$j < [llength $::servers]} {incr j} {
+        set cfg [R $j cluster slots]
+        foreach shard $cfg {
+            for {set node_id 0} {$node_id < [llength [lindex $shard 3]]} {incr i} {
+                if {! [string match $match_string [lindex [lindex $shard 3 $node_id] 15]] || 
+                ! [string match "engine-version" [lindex [lindex $shard 3 $node_id] 14]]} {
+                    return 0
+                }
+            }
+        }
+    }
+    return 1
+}
+
+proc get_shards_field {shard_output shard_id node_id attrib_id} {
+    return [lindex [lindex [lindex $shard_output $shard_id 3] $node_id] $attrib_id]
+}
+
+
+start_cluster 3 4 {tags {external:skip cluster} } {
+test "Verify engine versions are propagated" {
+    wait_for_condition 50 100 {
+        [are_engine_version_propagated "255.255.255"] eq 1
+    } else {
+        fail "cluster engine versions were not propagated"
+    }
+
+    # Now that everything is propagated, assert everyone agrees
+    wait_for_cluster_propagation
+}
+
+test "Test restart will keep engine-version information" {
+    restart_server 0 true false
+    set shards_result [R 0 CLUSTER SHARDS]
+    assert_equal [get_shards_field $shards_result 0 0 14]  "engine-version"
+    assert_equal [get_shards_field $shards_result 0 0 15]  "255.255.255"
+
+    # As a sanity check, make sure everyone eventually agrees
+    wait_for_cluster_propagation
+}
+}


### PR DESCRIPTION
In order to know each node's engine-version easily, we added to the cluster bus the engine version of a node as an AUX extension. 
With that change every instance will know the engine version of each node in the cluster without sending any messages.